### PR TITLE
feat: adiciona verificacao de status para mudar

### DIFF
--- a/packages/api/src/controllers/company/companyCashback/CancelCashBackUseCase.ts
+++ b/packages/api/src/controllers/company/companyCashback/CancelCashBackUseCase.ts
@@ -1,8 +1,8 @@
+import { UpdateCompanyStatusByTransactionsUseCase } from './UpdateCompanyStatusByTransactionsUseCase'
 import { InternalError } from '../../../config/GenerateErros'
 import { TransactionStatusEnum } from '../../../enum/TransactionStatusEnum'
 import { prisma } from '../../../prisma'
 import { CancelTransactionUseCase } from '../../../useCases/cashback/CancelTransactionUseCase'
-import { UpdateCompanyStatusByTransactionsUseCase } from './UpdateCompanyStatusByTransactionsUseCase'
 
 interface CancelProps {
   transactionIDs: number[]

--- a/packages/api/src/controllers/company/companyCashback/UpdateCompanyStatusByTransactionsUseCase.ts
+++ b/packages/api/src/controllers/company/companyCashback/UpdateCompanyStatusByTransactionsUseCase.ts
@@ -4,6 +4,15 @@ import { CompanyStatusEnum } from '../../../enum/CompanyStatusEnum'
 
 export class UpdateCompanyStatusByTransactionsUseCase {
   async execute(companyId: string) {
+    const company = await prisma.company.findUnique({
+      where: { id: companyId },
+      select: {
+        companyStatus: { select: { description: true } },
+      },
+    })
+
+    if (company.companyStatus.description === CompanyStatusEnum.BLOCKED) return
+
     const overdueTransactionCounter = await prisma.transaction.count({
       where: {
         companiesId: companyId,

--- a/packages/api/src/useCases/shared/ExpireTransactionsUseCase.ts
+++ b/packages/api/src/useCases/shared/ExpireTransactionsUseCase.ts
@@ -86,7 +86,7 @@ export class ExpireTransactionsUseCase {
           companyId: company.id,
           paymentMethodId: 1,
           transactionIDs,
-        }
+        },
       )
     }
 


### PR DESCRIPTION
Se a empresa tiver o status bloqueado não muda para ativo ou inadimplente por cashback caso a empresa pague os cashbacks atrasados